### PR TITLE
Display some X509 cert info when using HTTPS

### DIFF
--- a/lib/elbping/display.rb
+++ b/lib/elbping/display.rb
@@ -47,9 +47,13 @@ module ElbPing
       code = status[:code]
       duration = status[:duration]
       exc = status[:exception]
-      exc_display = exc ? "exception=#{exc}" : ''
+      sslSubject = status[:sslSubject].join(',') if status[:sslSubject]
+      sslExpires = status[:sslExpires]
 
-      self.out "Response from #{node}: code=#{code.to_s} time=#{duration} ms #{exc_display}"
+      exc_display = exc ? "exception=#{exc}" : ''
+      ssl_display = (sslSubject and sslExpires) ? "ssl_cn=#{sslSubject} ssl_expires=#{sslExpires}" : ''
+
+      self.out "Response from #{node}: code=#{code.to_s} time=#{duration} ms #{ssl_display} #{exc_display}"
     end
 
     # Display summary of requests, responses, and latencies (for aggregate and per-node)


### PR DESCRIPTION
This is what I'm thinking of now. Example:

```
sub@asdf:~/projects/elbping$ bundle exec bin/elbping -c 1 https://www.heroku.com
Response from 54.243.82.181: code=405 time=374 ms ssl_cn=www.heroku.com ssl_expires=2015-10-08 12:00:00 UTC 
Response from 54.225.184.218: code=405 time=406 ms ssl_cn=www.heroku.com ssl_expires=2015-10-08 12:00:00 UTC 
Response from 174.129.247.167: code=405 time=375 ms ssl_cn=www.heroku.com ssl_expires=2015-10-08 12:00:00 UTC 
--- 54.243.82.181 statistics ---
1 requests, 1 responses, 0% loss
min/avg/max = 374/374/374 ms
--- 54.225.184.218 statistics ---
1 requests, 1 responses, 0% loss
min/avg/max = 406/406/406 ms
--- 174.129.247.167 statistics ---
1 requests, 1 responses, 0% loss
min/avg/max = 375/375/375 ms
--- total statistics ---
3 requests, 3 responses, 0% loss, 3 nodes
min/avg/max = 374/385/406 ms
```

Fixes #18 
