### PR TITLE
Add -l / --list to list all nodes in an ELB

### DIFF
--- a/elbping.gemspec
+++ b/elbping.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency "rake", "~> 10.0.4"
+  s.add_development_dependency "test-unit"
 
   s.homepage    =
     'https://github.com/heroku/elbping'

--- a/lib/elbping/cli.rb
+++ b/lib/elbping/cli.rb
@@ -19,6 +19,7 @@ module ElbPing
     OPTIONS[:count]         = ENV['PING_ELB_PINGCOUNT']     || 0
     OPTIONS[:timeout]       = ENV['PING_ELB_TIMEOUT']       || 10
     OPTIONS[:wait]          = ENV['PING_ELB_WAIT']          || 0
+    OPTIONS[:list]          = false
 
     # Build parser for command line options
     PARSER = OptionParser.new do |opts|
@@ -39,6 +40,10 @@ module ElbPing
       opts.on("-c COUNT", "--count COUNT", Integer,
         "Ping each node COUNT times (default: #{OPTIONS[:count]})") do |n|
         OPTIONS[:count] = n
+      end
+      opts.on("-l", "--list", Integer,
+        "Print the IP address of each node without pinging.") do |n|
+        OPTIONS[:list] = true
       end
     end
 
@@ -89,6 +94,13 @@ module ElbPing
         ElbPing::Display.error "Unable to query DNS for #{elb_uri.host}"
         ElbPing::Display.debug e
         exit(false)
+      end
+
+      if OPTIONS[:list]
+        nodes.each do |node|
+          puts node
+        end
+        exit(true)
       end
 
       if nodes.size < 1


### PR DESCRIPTION
This adds a `-l` or `--list` option to list the nodes for a given ELB instead of pinging. Useful for determining if the ELB has the max number of nodes allocated.

```
jroes-ltm7:elbping jroes$ elbping -l http://elb027179-1778060837.us-east-1.elb.amazonaws.com
54.204.11.224
23.21.84.59
23.21.183.239
23.23.231.146
...
jroes-ltm7:elbping jroes$ elbping -l http://elb027179-1778060837.us-east-1.elb.amazonaws.com | wc -l
     99
```